### PR TITLE
Fix for modernizr gulp task

### DIFF
--- a/gulp_tasks/modernizr.js
+++ b/gulp_tasks/modernizr.js
@@ -1,11 +1,12 @@
 var modernizr = require('modernizr'),
     fs = require('fs'),
+    mkdirp = require('mkdirp'),
     paths = require('./paths');
 
 var task = function () {
     modernizr.build(require('../gulpconfig').modernizr, function (result) {
         if (!fs.existsSync(paths.js_libs.dest)) {
-            fs.mkdir(paths.js_libs.dest);
+            mkdirp.sync(paths.js_libs.dest);
             fs.writeFile(paths.js_libs.dest + 'modernizr.js', result);
         }
     });

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jwt-decode": "^2.0.1",
     "merge-stream": "^1.0.0",
     "modernizr": "^3.2.0",
+    "node-mkdirp": "0.0.1",
     "node-sass": "^3.4.2",
     "open": "0.0.5",
     "pluralize-ru": "^1.0.1",


### PR DESCRIPTION
Fix for error:

```
Error: ENOENT: no such file or directory, mkdir 'build/static/js/libs/'
```

because fs.mkdir can't create directory recursivly
